### PR TITLE
Rename the `MessageInEnvelopSerializer` to `MessageInEnvelopeSerializer`

### DIFF
--- a/src/Envelope/Serializer/MessageInEnvelopeSerializer.php
+++ b/src/Envelope/Serializer/MessageInEnvelopeSerializer.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Serialization\Envelope\Serializer;
 
 use SimpleBus\Serialization\Envelope\Envelope;
 
-interface MessageInEnvelopSerializer
+interface MessageInEnvelopeSerializer
 {
     /**
      * Serialize a Message to a string representation of that Message wrapped in an Envelope

--- a/src/Envelope/Serializer/StandardMessageInEnvelopeSerializer.php
+++ b/src/Envelope/Serializer/StandardMessageInEnvelopeSerializer.php
@@ -6,7 +6,7 @@ use SimpleBus\Serialization\Envelope\Envelope;
 use SimpleBus\Serialization\Envelope\EnvelopeFactory;
 use SimpleBus\Serialization\ObjectSerializer;
 
-class StandardMessageInEnvelopeSerializer implements MessageInEnvelopSerializer
+class StandardMessageInEnvelopeSerializer implements MessageInEnvelopeSerializer
 {
     /**
      * @var EnvelopeFactory


### PR DESCRIPTION
Fixed the typo in class name and add the old one for BC reasons https://github.com/SimpleBus/Serialization/issues/4

Also involves these merge requests:
* https://github.com/SimpleBus/SimpleBusBernardBundleBridge/pull/7
* https://github.com/SimpleBus/RabbitMQBundleBridge/pull/28
* https://github.com/SimpleBus/JMSSerializerBundleBridge/pull/6
* https://github.com/SimpleBus/docs/pull/38
* https://github.com/SimpleBus/Asynchronous/pull/10
